### PR TITLE
Automatically Select Organism in map_genes Based on Repository Name

### DIFF
--- a/popv/hub/_model.py
+++ b/popv/hub/_model.py
@@ -380,7 +380,7 @@ class HubModel:
         with cellxgene_census.open_soma() as census:
             var_df = cellxgene_census.get_var(
                 census,
-                organism="homo_sapiens",
+                organism=organism = 'mus_musculus' if 'tabula_muris' in self.repo_name else 'homo_sapiens'
             )
             feature_dict = dict(zip(var_df[gene_symbols], var_df["feature_id"], strict=True))
         adata.var["old_index"] = adata.var_names

--- a/popv/hub/_model.py
+++ b/popv/hub/_model.py
@@ -379,8 +379,7 @@ class HubModel:
         """Map genes to CELLxGENE census gene IDs."""
         with cellxgene_census.open_soma() as census:
             var_df = cellxgene_census.get_var(
-                census,
-                organism = 'mus_musculus' if 'tabula_muris' in self.repo_name else 'homo_sapiens'
+                census, organism="mus_musculus" if "tabula_muris" in self.repo_name else "homo_sapiens"
             )
             feature_dict = dict(zip(var_df[gene_symbols], var_df["feature_id"], strict=True))
         adata.var["old_index"] = adata.var_names

--- a/popv/hub/_model.py
+++ b/popv/hub/_model.py
@@ -380,7 +380,7 @@ class HubModel:
         with cellxgene_census.open_soma() as census:
             var_df = cellxgene_census.get_var(
                 census,
-                organism=organism = 'mus_musculus' if 'tabula_muris' in self.repo_name else 'homo_sapiens'
+                organism = 'mus_musculus' if 'tabula_muris' in self.repo_name else 'homo_sapiens'
             )
             feature_dict = dict(zip(var_df[gene_symbols], var_df["feature_id"], strict=True))
         adata.var["old_index"] = adata.var_names


### PR DESCRIPTION
This update enhances the map_genes method by making the organism selection dynamic based on the dataset source. Specifically:

The organism is now determined automatically from self.repo_name:

1. If 'tabula_muris' is present, organism is set to 'mus_musculus'

2. Otherwise, it defaults to 'homo_sapiens'